### PR TITLE
Update tests

### DIFF
--- a/AccessCheckTests/NativeMethods.txt
+++ b/AccessCheckTests/NativeMethods.txt
@@ -3,3 +3,4 @@ DuplicateToken
 FILE_ACCESS_RIGHTS
 GetCurrentProcess
 OpenProcessToken
+WIN32_ERROR


### PR DESCRIPTION
Removes the invalid `PassNullNull` test; updates the other tests w/ appropriate asserts and some comments. 